### PR TITLE
using new non depreciated ReactDOM method

### DIFF
--- a/src/LazySizes.js
+++ b/src/LazySizes.js
@@ -1,5 +1,6 @@
 import 'lazysizes';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Invariant from 'invariant';
 
 class LazySizes extends React.Component {
@@ -25,13 +26,13 @@ class LazySizes extends React.Component {
     }
   };
   componentWillUpdate = () => {
-    let lazyElement = React.findDOMNode(this.refs.lazyElement);
+    let lazyElement = ReactDOM.findDOMNode((this.refs.lazyElement);
     if (lazyElement.classList.contains('lazyloaded')) {
       lazyElement.classList.remove('lazyloaded');
     }
   };
   componentDidUpdate = () => {
-    let lazyElement = React.findDOMNode(this.refs.lazyElement);
+    let lazyElement = ReactDOM.findDOMNode((this.refs.lazyElement);
     if (!lazyElement.classList.contains('lazyload')) {
       lazyElement.classList.add('lazyload');
     }


### PR DESCRIPTION
from react v0.1.4 Upgrade guide:
https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html

Each of these changes will continue to work as before with a new warning until the release of 0.15 so you can upgrade your code gradually.

Due to the DOM node refs change mentioned above, this.getDOMNode() is now deprecated and ReactDOM.findDOMNode(this) can be used instead. Note that in most cases, calling findDOMNode is now unnecessary – see the example above in the “DOM node refs” section.
